### PR TITLE
Support large images

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,9 +22,17 @@ Exported method for generating a CollectionFS transformWrite function
 */
 resizeImageStream = function(options) {
   return function(fileObj, readStream, writeStream) {
-    // readStream comes as one chunk
-    readStream.on('readable', Meteor.bindEnvironment(function() {
-      var input = readStream.read();
+    var chunks = [];
+
+    readStream.on('readable', function() {
+      // Save each incoming chunk of the read stream
+      var chunk = readStream.read();
+      chunks.push(chunk);
+    });
+
+    readStream.on('end', Meteor.bindEnvironment(function() {
+      // Concatenate all of the chunks together to get the full input buffer
+      var input = Buffer.concat(chunks);
 
       options.format = options.format || fileObj.original.type;
 

--- a/test/index.js
+++ b/test/index.js
@@ -3,9 +3,6 @@
 
 var PREFIX = 'numtel:cfs-image-resize - ';
 var ASSET_DIR = 'assets/packages/local-test_numtel_cfs-image-resize/';
-var READ_STREAM_OPTS = {
-  highWaterMark: 10 * 1024 * 1024 // 10MB chunk size, larger than input file
-}
 
 var MBE = Meteor.bindEnvironment;
 var fs = Npm.require('fs');
@@ -76,7 +73,7 @@ Object.keys(MATRIX).forEach(function(testName) {
     var paths = testSettings.paths.call(testSettings, options);
     Tinytest.addAsync(PREFIX + testName + ' ' + paths.file,
       function (test, done) {
-        var readStream = fs.createReadStream(paths.input, READ_STREAM_OPTS);
+        var readStream = fs.createReadStream(paths.input);
         var writeStream = fs.createWriteStream(paths.output);
         var resizer = resizeImageStream(options);
 


### PR DESCRIPTION
Currently, this library assumes that all of the image data will fit within a single ReadStream chunk. When this assumption is incorrect, only the first chunk of the image is sent to Jimp, and Jimp crashes on that malformed image. This PR makes `resizeImageStream` save incoming chunks from the read stream and then combine them to produce the full input buffer.
