### PR TITLE
shouldn't push null chunk to chunks array

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,9 @@ resizeImageStream = function(options) {
     readStream.on('readable', function() {
       // Save each incoming chunk of the read stream
       var chunk = readStream.read();
-      chunks.push(chunk);
+      if (chunk) {
+        chunks.push(chunk);
+      }
     });
 
     readStream.on('end', Meteor.bindEnvironment(function() {


### PR DESCRIPTION
Fix bug after updating to Meteor 1.4.1 :  `Exception in callback of async function: TypeError: Cannot read property 'length' of null`
